### PR TITLE
Fix externally-managed-environment error with proper virtual environment support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -56,7 +56,12 @@ rm ~/.claude-mcp-servers/gemini-collab/server.py.bak
 # Install Python dependencies
 echo ""
 echo "📦 Installing Python dependencies..."
-pip3 install google-generativeai --quiet
+cd ~/.claude-mcp-servers/gemini-collab
+python3 -m venv venv
+source venv/bin/activate
+pip install google-generativeai --quiet
+deactivate
+cd -
 
 # Remove any existing MCP configuration
 echo ""
@@ -64,7 +69,7 @@ echo "🔧 Configuring Claude Code..."
 claude mcp remove gemini-collab 2>/dev/null || true
 
 # Add MCP server with global scope
-claude mcp add --scope user gemini-collab python3 ~/.claude-mcp-servers/gemini-collab/server.py
+claude mcp add --scope user gemini-collab ~/.claude-mcp-servers/gemini-collab/venv/bin/python ~/.claude-mcp-servers/gemini-collab/server.py
 
 echo ""
 echo -e "${GREEN}✅ Setup complete!${NC}"


### PR DESCRIPTION
## Summary
Fixes the "externally-managed-environment" error that prevents installation on modern Python systems following PEP 668.

## Problem
The current setup script fails on:
- macOS with Homebrew Python
- Ubuntu 23.04+ 
- Debian 12+
- Any system with PEP 668 externally-managed environments

Error: `error: externally-managed-environment × This environment is externally managed`

## Solution
- **Creates dedicated virtual environment** for MCP server dependencies
- **Installs google-generativeai in isolated venv** instead of system-wide
- **Uses venv Python interpreter** for MCP server execution
- **Maintains backward compatibility** with older systems

## Key Changes
```bash
# Before (fails on modern systems)
pip3 install google-generativeai --quiet
claude mcp add --scope user gemini-collab python3 ~/.claude-mcp-servers/gemini-collab/server.py

# After (works everywhere)  
cd ~/.claude-mcp-servers/gemini-collab
python3 -m venv venv
source venv/bin/activate
pip install google-generativeai --quiet
claude mcp add --scope user gemini-collab ~/.claude-mcp-servers/gemini-collab/venv/bin/python ~/.claude-mcp-servers/gemini-collab/server.py
```

## Comparison with PR #2
Unlike PR #2 which only works if you're already in a virtual environment, this solution **creates its own venv** and works for all users out of the box.

## Test Plan
- ✅ Tested on macOS with Homebrew Python
- ✅ Resolves externally-managed-environment error  
- ✅ MCP server starts successfully
- ✅ Backward compatible with older systems

This is the **industry standard approach** recommended by Python packaging guidelines and ensures reliable installation across all modern Python environments.