### PR TITLE
feat: Add system prompt support and model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ mcp__gemini-collab__gemini_code_review
 mcp__gemini-collab__gemini_brainstorm
   topic: "How to scale a web app to 1M users"
 
+# Use a specific model (New Feature)
+mcp__gemini-collab__ask_gemini
+  prompt: "Analyze this long document..."
+  model: "gemini-1.5-pro-latest"  # For long context tasks
+
 Or simply ask claude code to correlate with Gemini, it is not a rocket sciene... (Author's note) 
 ```
 
@@ -90,6 +95,26 @@ claude mcp add --scope user gemini-collab python3 ~/.claude-mcp-servers/gemini-c
 ## 🔑 Update API Key
 
 Edit `~/.claude-mcp-servers/gemini-collab/server.py` and replace the API key.
+
+## 📝 System Prompt Support (New Feature)
+
+Add a system prompt to customize Gemini's behavior (like CLAUDE.md for Claude).
+
+1. Create `~/.claude-mcp-servers/gemini-collab/GEMINI.md`
+2. Add your instructions
+3. Restart Claude Code
+
+That's it! Gemini will use your instructions automatically.
+
+## 🤖 Model Selection (New Feature)
+
+Use different Gemini models for different tasks:
+
+- **gemini-1.5-pro-latest** - For long documents (up to 1M tokens)
+- **gemini-2.0-flash** - Default, fast and smart
+- **gemini-2.0-flash-lite** - For quick responses
+
+Just add `model: "gemini-1.5-pro-latest"` to your request!
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Summary
This PR adds two powerful yet simple features to the Claude-Gemini MCP server:
- **System prompt support** - Customize Gemini's behavior with a GEMINI.md file (similar to CLAUDE.md)
- **Model selection** - Choose from 7 different Gemini models at runtime
- **Environment variable configuration** - Set model and prompt path via config

## Motivation
Claude Code has CLAUDE.md for system prompts, but Gemini didn't have this capability. This PR brings feature parity while maintaining the project's beginner-friendly philosophy.

## Changes
### 1. System Prompt Support
- Reads from `~/.claude-mcp-servers/gemini-collab/GEMINI.md` by default
- Configurable via `GEMINI_SYSTEM_PROMPT` environment variable
- Auto-creates template file if missing
- Silently continues if file cannot be read

### 2. Model Selection
- Support for all 7 Gemini models (2.5, 2.0, 1.5, 1.0 families)
- Runtime selection via `model` parameter in requests
- Environment variable `GEMINI_MODEL` for default model
- Friendly error messages with available models list

### 3. Enhanced Features
- `include_system_prompt` parameter to control prompt inclusion
- Model info shown only when non-default model is used
- Emoji feedback for better user experience

## Breaking Changes
None\! The server works exactly as before if the new features aren't used.

## Testing
All features have been thoroughly tested:
- ✅ System prompt loading and application
- ✅ Model selection with validation
- ✅ Environment variable configuration
- ✅ Backward compatibility

## Example Usage
```python
# Use a different model
mcp__gemini__ask_gemini
  prompt: "Analyze this 500-page document..."
  model: "gemini-1.5-pro-latest"  # Long context model

# Disable system prompt for specific request
mcp__gemini__ask_gemini
  prompt: "Just answer directly"
  include_system_prompt: false
```

## Documentation
Updated README with clear instructions for both features, maintaining the beginner-friendly tone.